### PR TITLE
[42] fix awful windows countryflag unicode display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "debate-tools",
       "version": "0.1.0",
       "dependencies": {
-        "next": "14.1.0",
+        "flag-icons": "^7.2.2",
+        "next": "^14.1.0",
         "react": "^18",
         "react-dom": "^18",
         "react-use": "^17.5.0",
@@ -2030,6 +2031,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flag-icons": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/flag-icons/-/flag-icons-7.2.2.tgz",
+      "integrity": "sha512-9cC2y77npwpNJ1Whl3iACVFd/vR7ZQe9AwN8BRDJU2sZROMpEzIC3tOT1qbRRm/QS9b9UTXBHEKAO4I6d7L0xg=="
     },
     "node_modules/flat-cache": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "next": "14.1.0",
+    "flag-icons": "^7.2.2",
+    "next": "^14.1.0",
     "react": "^18",
     "react-dom": "^18",
     "react-use": "^17.5.0",

--- a/src/components/FlagIcon.tsx
+++ b/src/components/FlagIcon.tsx
@@ -16,7 +16,7 @@ const FlagIcon = (props: FlagIconProps) => {
       flagCode = props.lang;
     }
   }
-  return <span className={"h-5 w-5 fi fi-" + flagCode}></span>;
+  return <span className={"h-[12px] scale-x-[1.15] fi fi-" + flagCode}></span>;
 };
 
 export { FlagIcon };

--- a/src/components/FlagIcon.tsx
+++ b/src/components/FlagIcon.tsx
@@ -1,0 +1,22 @@
+import { langsArray, language } from "@/types/language";
+import "/node_modules/flag-icons/css/flag-icons.min.css";
+
+type FlagIconProps = {
+  lang: language;
+};
+
+const FlagIcon = (props: FlagIconProps) => {
+  let flagCode = "";
+  switch (props.lang) {
+    case "en": {
+      flagCode = "gb";
+      break;
+    }
+    default: {
+      flagCode = props.lang;
+    }
+  }
+  return <span className={"h-5 w-5 fi fi-" + flagCode}></span>;
+};
+
+export { FlagIcon };

--- a/src/components/GenericSelect.tsx
+++ b/src/components/GenericSelect.tsx
@@ -5,6 +5,7 @@ import { IconBlankIcon } from "./icons/BlankIcon";
 
 type option = {
   value: string;
+  icon?: React.JSX.Element;
   exec?: () => void;
 };
 
@@ -34,9 +35,12 @@ const GenericSelect = (props: GenericSelectProps) => {
     <div className="flex flex-row justify-between relative">
       <p className="text-neutral-500">{props.text}</p>
       <button
-        className="flex flex-row gap-2 text-neutral-500 select-none"
+        className="flex flex-row gap-2 text-neutral-500 select-none items-center"
         onClick={() => setSelectOpen(true)}
       >
+        {props.options.find((option) => {
+          return option.value === props.value;
+        })?.icon || ""}
         {props.value}
         <IconChevronDown moreClass="scale-[.75]" />
       </button>
@@ -49,25 +53,26 @@ const GenericSelect = (props: GenericSelectProps) => {
             border-neutral-700 shadow shadow-black select-none
           `}
         >
-          {props.options.map((el: option) => {
+          {props.options.map((element: option) => {
             return (
               <button
-                key={el.value}
+                key={element.value}
                 onClick={() => {
-                  if (el.exec) el.exec();
+                  if (element.exec) element.exec();
                   setSelectOpen(false);
                 }}
                 className={`
                   flex flex-row gap-1 rounded
-                  pr-3 hover:bg-neutral-700
+                  pr-3 hover:bg-neutral-700 items-center
                 `}
               >
-                {props.value === el.value ? (
+                {props.value === element.value ? (
                   <IconCheck moreClass="scale-[.65]" />
                 ) : (
                   <IconBlankIcon />
                 )}
-                {el.value}
+                {element.icon}
+                {element.value}
               </button>
             );
           })}

--- a/src/components/LangSwitch.tsx
+++ b/src/components/LangSwitch.tsx
@@ -3,6 +3,7 @@ import { useLang, getSpecificLangString } from "@/lib/useLang";
 import { langsArray, langsPublicBlacklist } from "@/types/language";
 import { useContext } from "react";
 import { GenericSelect } from "./GenericSelect";
+import { FlagIcon } from "./FlagIcon";
 
 const LangSwitchComponent = () => {
   const langContext = useContext(LangContext);
@@ -15,6 +16,7 @@ const LangSwitchComponent = () => {
           .filter((lang) => !langsPublicBlacklist.includes(lang))
           .map((lang) => {
             return {
+              icon: <FlagIcon lang={lang} />,
               value: getSpecificLangString("selfLanguageString", lang),
               exec: () => langContext.setLang(lang),
             };

--- a/src/data/strings.json
+++ b/src/data/strings.json
@@ -7,11 +7,11 @@
     "es": "Lengua"
   },
   "selfLanguageString": {
-    "en": "🇬🇧 English",
-    "pl": "🇵🇱 polski",
-    "de": "🇩🇪 Deutsch",
-    "jp": "🇯🇵 日本語",
-    "es": "🇪🇸 Español"
+    "en": "English",
+    "pl": "polski",
+    "de": "Deutsch",
+    "jp": "日本語",
+    "es": "Español"
   },
   "debateTools": {
     "en": "Debate Tools",


### PR DESCRIPTION
Implements #42 by replacing unicode flags with SVG icons imported from [lipis/flag-icons](https://github.com/lipis/flag-icons). New languages will be covered automatically, as long as the language codes are compliant with ISO 3166-1-alpha-2 (since we use `en` for English, I needed to handle that separately). We probably should expand `CONTRIBUTING.md` with instructions on adding locales, as the list of requirements keeps growing.

Open select:
![image](https://github.com/debatecore/debate-tools/assets/60257096/fe823907-fca2-4d75-8aa1-854534630e23)

Closed select:
![image](https://github.com/debatecore/debate-tools/assets/60257096/26779776-fff9-4278-b2a0-895cdcce6af4)
