### PR TITLE
[56] fix ztm bell paths

### DIFF
--- a/src/types/soundPack.ts
+++ b/src/types/soundPack.ts
@@ -23,12 +23,12 @@ export { defaultSoundPack };
 
 const ztmPoznańSoundPack: soundPack = {
   name: "ZTM Poznań",
-  pingProtectedTime: "/KBING!",
-  pingSpeechEnd: "/KBING! - Gong.mp3",
+  pingProtectedTime: "/KBING!.mp3",
+  pingSpeechEnd: "/KBING!.mp3",
   adVocemSound: "/KZADAN.mp3",
   debateEndSound: "/KONCTR.mp3",
 };
 export { ztmPoznańSoundPack };
 
-const soundPacks: Array<soundPack> = [defaultSoundPack, ztmPoznańSoundPack] as const;
+const soundPacks: soundPack[] = [defaultSoundPack, ztmPoznańSoundPack] as const;
 export { soundPacks };


### PR DESCRIPTION
Closes #56 

<img width="435" alt="image" src="https://github.com/debatecore/debate-tools/assets/56172798/da9d3e35-a284-46dd-85cd-58b006bfb5fe">

The paths replaced above were the culprit.

<img width="764" alt="image" src="https://github.com/debatecore/debate-tools/assets/56172798/ef60529e-3d15-4e59-91b3-602df0ee9c44">

This change made to avoid Prettier forcing me to break the line into multiple and thus producing a bigger diff, as it was 86 characters compared to 81.