### PR TITLE
[68, 70] fix MOW logos not loading & add PND branding logo option

### DIFF
--- a/src/components/ClockDisplayImage.tsx
+++ b/src/components/ClockDisplayImage.tsx
@@ -5,9 +5,10 @@ import { useLang } from "@/lib/useLang";
 import Image from "next/image";
 import { useContext, useState } from "react";
 
-const ClockDisplayImage = ({}) => {
+const ClockDisplayImage = () => {
   const currentDebateConf = useContext(DebateContext).conf;
   const clockImageName = currentDebateConf.clockImageName;
+
   const [clockImageLoaded, setClockImageLoaded] = useState(false);
   const loadingText = useLang("loading");
 
@@ -18,8 +19,8 @@ const ClockDisplayImage = ({}) => {
       )}
       {clockImageName === "MOW2018" && (
         <Image
-          src={"/displayimages/Musketeer.png"}
-          alt="Musketeers of Words logo"
+          src={"/display-images/MOW2018.png"}
+          alt="Musketeers of Words logo (2018-2023)"
           width={80}
           height={64}
           className="mt-32"
@@ -28,8 +29,8 @@ const ClockDisplayImage = ({}) => {
       )}
       {clockImageName === "MOW2024" && (
         <Image
-          src={"/displayimages/MOW.png"}
-          alt="Musketeers of Words logo"
+          src={"/display-images/MOW2024.png"}
+          alt="Musketeers of Words logo (since 2024)"
           width={60}
           height={60}
           className="mt-36 rounded-full"


### PR DESCRIPTION
* fixed bug caused by path mismatch
* expanded upon logo alt text
* changed misc. whitespace
* removed unused component prop

This closes #70 and #68