### PR TITLE
[87] fix clock images

### DIFF
--- a/src/app/oxford-debate/setup/page.tsx
+++ b/src/app/oxford-debate/setup/page.tsx
@@ -28,7 +28,8 @@ export default function OxfordDebateSetup() {
   const clockImageCustom = useLang("clockImageCustomOption");
   const soundPackSelect = useLang("soundPackSelect");
   const soundPackDefault = useLang("defaultSoundsOption");
-  const [customClockImageSelected, setCustomClockImageSelected] = useState(false);
+  const [customClockImageSelected, setCustomClockImageSelected] =
+    useState(false);
 
   const getDisplayNameOfClockImage = (clockImageName: string) => {
     switch (clockImageName) {
@@ -42,11 +43,11 @@ export default function OxfordDebateSetup() {
   };
 
   const setClockImage = (clockImageName: displayImageType) => {
-    debateContext.setConf(
-      {...debateContext.conf,
+    debateContext.setConf({
+      ...debateContext.conf,
       clockImageName: clockImageName,
     });
-    };
+  };
 
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     if (!e.target) return;
@@ -80,10 +81,9 @@ export default function OxfordDebateSetup() {
         <DebateConfStringsPanel />
         <hr className="border-b-2 rounded border-neutral-800 my-2" />
         <GenericSelect
+          id="clockimageselect"
           text={clockImageSelect}
-          value={getDisplayNameOfClockImage(
-            debateContext.conf.clockImageName
-          )}
+          value={getDisplayNameOfClockImage(debateContext.conf.clockImageName)}
           options={displayImageTypeArray.map((element) => {
             return {
               value: getDisplayNameOfClockImage(element),
@@ -100,6 +100,7 @@ export default function OxfordDebateSetup() {
           hidden={!customClockImageSelected}
         />
         <GenericSelect
+          id="soundpackselect"
           text={soundPackSelect}
           value={
             debateContext.conf.soundPack.name === "default"

--- a/src/components/ClockDisplayImage.tsx
+++ b/src/components/ClockDisplayImage.tsx
@@ -22,9 +22,8 @@ const ClockDisplayImage = () => {
           alt="Musketeers of Words logo (2018-2023)"
           width={80}
           height={64}
-          className="mt-32"
+          className={`mt-32 ${!clockImageLoaded && "opacity-0"}`}
           onLoad={() => setClockImageLoaded(true)}
-          hidden={!clockImageLoaded}
         />
       )}
       {clockImageName === "MOW2024" && (
@@ -33,9 +32,8 @@ const ClockDisplayImage = () => {
           alt="Musketeers of Words logo (since 2024)"
           width={60}
           height={60}
-          className="mt-36 rounded-full"
+          className={`mt-36 rounded-full ${!clockImageLoaded && "opacity-0"}`}
           onLoad={() => setClockImageLoaded(true)}
-          hidden={!clockImageLoaded}
         />
       )}
       {clockImageName === "PND2024" && (
@@ -44,9 +42,8 @@ const ClockDisplayImage = () => {
           alt="Poznańska Noc Debaty logo (since 2024)"
           width={100}
           height={100}
-          className="mt-40"
+          className={`mt-40 ${!clockImageLoaded && "opacity-0"}`}
           onLoad={() => setClockImageLoaded(true)}
-          hidden={!clockImageLoaded}
         />
       )}
       {clockImageName === "custom" &&
@@ -56,9 +53,8 @@ const ClockDisplayImage = () => {
             alt="Custom logo"
             width={60}
             height={60}
-            className="mt-36"
+            className={`mt-36 ${!clockImageLoaded && "opacity-0"}`}
             onLoad={() => setClockImageLoaded(true)}
-            hidden={!clockImageLoaded}
           />
         )}
     </span>

--- a/src/components/ClockDisplayImage.tsx
+++ b/src/components/ClockDisplayImage.tsx
@@ -12,14 +12,17 @@ const ClockDisplayImage = () => {
   const loadingText = useLang("loading");
 
   return (
-    <span className="absolute w-full h-full flex justify-center items-center">
+    <div
+      className="absolute w-full h-full flex justify-center items-center z-50"
+      id="clockDisplayImageParent"
+    >
       {!clockImageLoaded && (
         <div className="w-15 h-15 pt-32">{loadingText}</div>
       )}
       {clockImageName === "MOW2018" && (
         <Image
           src={"/display-images/MOW2018.png"}
-          alt="Musketeers of Words logo (2018-2023)"
+          alt={`${clockImageName} | Musketeers of Words logo (2018-2023)`}
           width={80}
           height={64}
           className={`mt-32 ${!clockImageLoaded && "opacity-0"}`}
@@ -29,7 +32,7 @@ const ClockDisplayImage = () => {
       {clockImageName === "MOW2024" && (
         <Image
           src={"/display-images/MOW2024.png"}
-          alt="Musketeers of Words logo (since 2024)"
+          alt={`${clockImageName} | Musketeers of Words logo (since 2024)`}
           width={60}
           height={60}
           className={`mt-36 rounded-full ${!clockImageLoaded && "opacity-0"}`}
@@ -39,7 +42,7 @@ const ClockDisplayImage = () => {
       {clockImageName === "PND2024" && (
         <Image
           src={"/display-images/PND2024.png"}
-          alt="Poznańska Noc Debaty logo (since 2024)"
+          alt={`${clockImageName} | Poznańska Noc Debaty logo (since 2024)`}
           width={100}
           height={100}
           className={`mt-40 ${!clockImageLoaded && "opacity-0"}`}
@@ -57,7 +60,7 @@ const ClockDisplayImage = () => {
             onLoad={() => setClockImageLoaded(true)}
           />
         )}
-    </span>
+    </div>
   );
 };
 

--- a/src/components/ClockDisplayImage.tsx
+++ b/src/components/ClockDisplayImage.tsx
@@ -27,6 +27,7 @@ const ClockDisplayImage = () => {
           height={64}
           className={`mt-32 ${!clockImageLoaded && "opacity-0"}`}
           onLoad={() => setClockImageLoaded(true)}
+          data-loaded={clockImageLoaded}
         />
       )}
       {clockImageName === "MOW2024" && (
@@ -37,6 +38,7 @@ const ClockDisplayImage = () => {
           height={60}
           className={`mt-36 rounded-full ${!clockImageLoaded && "opacity-0"}`}
           onLoad={() => setClockImageLoaded(true)}
+          data-loaded={clockImageLoaded}
         />
       )}
       {clockImageName === "PND2024" && (
@@ -47,6 +49,7 @@ const ClockDisplayImage = () => {
           height={100}
           className={`mt-40 ${!clockImageLoaded && "opacity-0"}`}
           onLoad={() => setClockImageLoaded(true)}
+          data-loaded={clockImageLoaded}
         />
       )}
       {clockImageName === "custom" &&
@@ -58,6 +61,7 @@ const ClockDisplayImage = () => {
             height={60}
             className={`mt-36 ${!clockImageLoaded && "opacity-0"}`}
             onLoad={() => setClockImageLoaded(true)}
+            data-loaded={clockImageLoaded}
           />
         )}
     </div>

--- a/src/components/ClockDisplayImage.tsx
+++ b/src/components/ClockDisplayImage.tsx
@@ -17,7 +17,7 @@ const ClockDisplayImage = () => {
       id="clockDisplayImageParent"
     >
       {!clockImageLoaded && (
-        <div className="w-15 h-15 pt-32">{loadingText}</div>
+        <div className="w-15 h-15 pt-32 absolute">{loadingText}</div>
       )}
       {clockImageName === "MOW2018" && (
         <Image

--- a/src/components/GenericSelect.tsx
+++ b/src/components/GenericSelect.tsx
@@ -10,6 +10,7 @@ type option = {
 };
 
 type GenericSelectProps = {
+  id: string;
   text: string;
   value: string;
   options: option[];
@@ -32,10 +33,16 @@ const GenericSelect = (props: GenericSelectProps) => {
   }, [selectOpen]);
 
   return (
-    <div className="flex flex-row justify-between relative">
-      <p className="text-neutral-500">{props.text}</p>
+    <div
+      className="flex flex-row justify-between relative"
+      id={`${props.id}-container`}
+    >
+      <p className="text-neutral-500" id={`${props.id}-text`}>
+        {props.text}
+      </p>
       <button
         className="flex flex-row gap-2 text-neutral-500 select-none items-center"
+        id={`${props.id}-selectbutton`}
         onClick={() => setSelectOpen(true)}
       >
         {props.options.find((option) => {
@@ -47,6 +54,7 @@ const GenericSelect = (props: GenericSelectProps) => {
       {selectOpen ? (
         <div
           ref={refSelectMenu}
+          id={`${props.id}-optionscontainer`}
           className={`
             absolute top-0 right-0 flex flex-col z-50
             bg-neutral-800 rounded-md border-2 p-1 gap-1
@@ -61,6 +69,7 @@ const GenericSelect = (props: GenericSelectProps) => {
                   if (element.exec) element.exec();
                   setSelectOpen(false);
                 }}
+                id={`${props.id}-option-${element.value}`}
                 className={`
                   flex flex-row gap-1 rounded
                   pr-3 hover:bg-neutral-700 items-center

--- a/src/components/LangSwitch.tsx
+++ b/src/components/LangSwitch.tsx
@@ -9,6 +9,7 @@ const LangSwitchComponent = () => {
   const langContext = useContext(LangContext);
   return (
     <GenericSelect
+      id="langswitchselect"
       text={useLang("language")}
       value={getSpecificLangString("selfLanguageString", langContext.lang)}
       options={[

--- a/tests/clockimage.test.ts
+++ b/tests/clockimage.test.ts
@@ -19,11 +19,10 @@ predefinedImagesToTest.forEach((imageid) => {
     await page.getByRole("button", { name: strings.startDebate.en }).click();
     await page.waitForURL("http://localhost:3000/oxford-debate");
 
-    await page.getByRole("img", { name: imageid }).click();
-    const screenshot = await page.screenshot({
-      path: `screenshot-${imageid}-${browserName}.jpg`,
-      fullPage: true,
-    });
+    const img = await page.getByRole("img", { name: imageid });
+    await expect(img).toHaveJSProperty("complete", true);
+
+    const screenshot = await page.screenshot({ fullPage: true });
     await testinfo.attach("image screenshot", {
       body: screenshot,
       contentType: "image/jpg",

--- a/tests/clockimage.test.ts
+++ b/tests/clockimage.test.ts
@@ -7,10 +7,7 @@ const predefinedImagesToTest = displayImageTypeArray.filter(
 );
 
 predefinedImagesToTest.forEach((imageid) => {
-  test(`setup->display of image: ${imageid}`, async ({
-    page,
-    browserName,
-  }, testinfo) => {
+  test(`setup->display of image: ${imageid}`, async ({ page }, testinfo) => {
     await page.goto("http://localhost:3000/oxford-debate/setup");
 
     await page.locator("#clockimageselect-selectbutton").click();
@@ -21,11 +18,15 @@ predefinedImagesToTest.forEach((imageid) => {
 
     const img = await page.getByRole("img", { name: imageid });
     await expect(img).toHaveJSProperty("complete", true);
+    await expect(img).toHaveAttribute("data-loaded", "true");
 
     const screenshot = await page.screenshot({ fullPage: true });
-    await testinfo.attach("image screenshot", {
-      body: screenshot,
-      contentType: "image/jpg",
-    });
+    await testinfo.attach(
+      `setup->display of image: ${imageid} test - full page screenshot`,
+      {
+        body: screenshot,
+        contentType: "image/jpg",
+      }
+    );
   });
 });

--- a/tests/clockimage.test.ts
+++ b/tests/clockimage.test.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+import strings from "@/data/strings.json";
+import { displayImageTypeArray } from "@/types/debate";
+
+const predefinedImagesToTest = displayImageTypeArray.filter(
+  (element) => !["null", "custom"].includes(element)
+);
+
+predefinedImagesToTest.forEach((imageid) => {
+  test(`setup->display of image: ${imageid}`, async ({
+    page,
+    browserName,
+  }, testinfo) => {
+    await page.goto("http://localhost:3000/oxford-debate/setup");
+
+    await page.locator("#clockimageselect-selectbutton").click();
+    await page.locator(`#clockimageselect-option-${imageid}`).click();
+
+    await page.getByRole("button", { name: strings.startDebate.en }).click();
+    await page.waitForURL("http://localhost:3000/oxford-debate");
+
+    await page.getByRole("img", { name: imageid }).click();
+    const screenshot = await page.screenshot({
+      path: `screenshot-${imageid}-${browserName}.jpg`,
+      fullPage: true,
+    });
+    await testinfo.attach("image screenshot", {
+      body: screenshot,
+      contentType: "image/jpg",
+    });
+  });
+});


### PR DESCRIPTION
Fixes the clock images. Closes #87. Presumably, the dependency version changes introduced in a53ea2824e02ff84b8edfc55000f91b5b928e352 made it so that the onLoad callback didn't fire if the element in question wasn't rendered. Swapping a hidden attribute for an opacity of 0 allows the element to render even if it isn't ready, and only show once onLoad fired, fixing the issue.

My thoughts copied from issue thread:

---

> No error is thrown on Chrome based browsers for me. That tracks with the following:

> It's not the image being broken, but the way we decide to show them. As seen below, simply commenting out the code that hides the element while it's loading is enough for it to show.

---

> After a bit of testing, it is my educated guess that the onLoad callback doesn't actually fire if the image element isn't rendered.

> You can force it to work by commenting out the hidden={} line (no. 49) and adding it back - since it rendered and is now presumably kept in memory or cache, the onLoad fires even after navigating to config view and back. If you refresh though, it stops working again. This happens no matter if we use hidden={}, the hidden class or conditionally avoid rendering it.

> This doesn't (!) happen if you apply opacity-0 instead of hiding it – since it renders the element anyway, and thus onLoad can fire.

> Looking at the node-modules diff for https://github.com/debatecore/debate-tools/commit/a53ea2824e02ff84b8edfc55000f91b5b928e352 as well as package.json, we permitted a nextjs minor version increment of 14.1.0 to 14.2.4, where this behavior could've changed as some kind of optimisation.

---

> > Looking at the node-modules diff for https://github.com/debatecore/debate-tools/commit/a53ea2824e02ff84b8edfc55000f91b5b928e352 as well as package.json, we permitted a nextjs minor version increment of 14.1.0 to 14.2.4, where this behavior could've changed as some kind of optimisation.

> This seems to have been a wrong assumption – downgrading explicitly back to next 14.1 or even 14.0 doesn't bring back old behavior.

> Nevertheless, turning down the opacity instead of hiding the image seems to fix the issue.