### PR TITLE
[90] add visual feedback to finished debates

### DIFF
--- a/src/app/oxford-debate/page.tsx
+++ b/src/app/oxford-debate/page.tsx
@@ -69,7 +69,7 @@ export default function OxfordDebate() {
   const startspeech = useLang("startspeech");
   const stopspeech = useLang("stopspeech");
   const debateconfig = useLang("oxfordDebateConfiguration");
-  const debatedoneenthusiastic = useLang("debateFinishedEnthusiastic");
+  const debateFinishedEnthusiastic = useLang("debateFinishedEnthusiastic");
 
   const conf = useContext(DebateContext).conf;
 
@@ -156,7 +156,7 @@ export default function OxfordDebate() {
           {/* debate finished */}
           {stage === 8 && (
             <div className="w-full h-full flex flex-col gap-5 justify-center items-center absolute">
-              <p className="text-3xl font-semibold">{debatedoneenthusiastic}</p>
+              <p className="text-3xl font-semibold">{debateFinishedEnthusiastic}</p>
               <p className="animate-wiggle text-6xl">{"🎉"}</p>
             </div>
           )}

--- a/src/app/oxford-debate/page.tsx
+++ b/src/app/oxford-debate/page.tsx
@@ -69,6 +69,7 @@ export default function OxfordDebate() {
   const startspeech = useLang("startspeech");
   const stopspeech = useLang("stopspeech");
   const debateconfig = useLang("oxfordDebateConfiguration");
+  const debatedoneenthusiastic = useLang("debateFinishedEnthusiastic");
 
   const conf = useContext(DebateContext).conf;
 
@@ -103,7 +104,11 @@ export default function OxfordDebate() {
       <p className="uppercase text-neutral-500">{anoxfordformatdebate}</p>
       <div className="relative flex flex-row justify-center mt-4 py-4">
         {/*  */}
-        <div className="hidden lg:flex w-1/3 text-right flex-col items-end">
+        <div
+          className={`hidden lg:flex w-1/3 text-right flex-col items-end ${
+            stage === 8 && "opacity-[.15]"
+          }`}
+        >
           <h2 className="text-2xl">
             {debate.conf.proTeam || "Anonymous" || "The Proposition"}
           </h2>
@@ -118,8 +123,8 @@ export default function OxfordDebate() {
         {/*  */}
         {/*  */}
         {/*  */}
-        <div className="w-full lg:w-1/3 text-center flex flex-col space-y-2 items-center">
-          <div>
+        <div className="w-full lg:w-1/3 text-center flex flex-col space-y-2 items-center relative">
+          <div className={stage === 8 ? "opacity-[.15]" : ""}>
             <p className="text-neutral-500 uppercase">
               {!adVocem ? stage_strings[stage] : "ad vocem"}
             </p>
@@ -146,12 +151,24 @@ export default function OxfordDebate() {
             beepProtected={debate.conf.beepProtectedTime && !adVocem}
             protectedTime={debate.conf.endProtectedTime}
             protectStart={!!debate.conf.startProtectedTime}
+            moreClass={stage === 8 ? "opacity-[.15]" : ""}
           />
+          {/* debate finished */}
+          {stage === 8 && (
+            <div className="w-full h-full flex flex-col gap-5 justify-center items-center absolute">
+              <p className="text-3xl font-semibold">{debatedoneenthusiastic}</p>
+              <p className="animate-wiggle text-6xl">{"🎉"}</p>
+            </div>
+          )}
         </div>
         {/*  */}
         {/*  */}
         {/*  */}
-        <div className="hidden lg:flex w-1/3 text-left flex-col items-start">
+        <div
+          className={`hidden lg:flex w-1/3 text-left flex-col items-start ${
+            stage === 8 && "opacity-[.15]"
+          }`}
+        >
           <h2 className="text-2xl">
             {debate.conf.oppTeam || "Anonymous" || "The Opposition"}
           </h2>

--- a/src/components/Clock.tsx
+++ b/src/components/Clock.tsx
@@ -14,6 +14,7 @@ const Clock = (props: {
   beepProtected?: boolean;
   protectedTime?: number;
   protectStart?: boolean;
+  moreClass?: string;
 }) => {
   const [time, setTime] = useState<number>(props.maxTime);
   const refCircle = useRef<SVGCircleElement>(null);
@@ -35,7 +36,7 @@ const Clock = (props: {
   const overtime = useLang("overtime");
 
   const delayInMs = 1000;
-  const clockColorsTransitionDuration = "350ms"
+  const clockColorsTransitionDuration = "350ms";
   const fullvolume = 1; // useAudio volume range is 0-1
 
   useEffect(() => {
@@ -52,7 +53,9 @@ const Clock = (props: {
   useInterval(() => setTime(time - 1), props.running ? delayInMs : null);
   return (
     <>
-      <div className="aspect-square min-w-64 flex flex-col space-y-1 justify-center items-center relative select-none">
+      <div
+        className={`aspect-square min-w-64 flex flex-col space-y-1 justify-center items-center relative select-none ${props.moreClass}`}
+      >
         <h2 className="text-5xl z-30">
           {time > 0 && (
             <>

--- a/src/data/strings.json
+++ b/src/data/strings.json
@@ -424,5 +424,9 @@
     "en": "and",
     "pl": "i",
     "de": "und"
+  },
+  "debateFinishedEnthusiastic": {
+    "en": "Debate finished!",
+    "pl": "Debata zakończona!"
   }
 }

--- a/src/data/strings.json
+++ b/src/data/strings.json
@@ -427,6 +427,7 @@
   },
   "debateFinishedEnthusiastic": {
     "en": "Debate finished!",
-    "pl": "Debata zakończona!"
+    "pl": "Debata zakończona!",
+    "de": "Debatte geendet!"
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,15 @@ const config: Config = {
         "gradient-conic":
           "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
       },
+      keyframes: {
+        wiggle: {
+          "0%, 100%": { transform: "rotate(-3deg)" },
+          "50%": { transform: "rotate(3deg)" },
+        },
+      },
+      animation: {
+        wiggle: "wiggle 1s ease-in-out infinite",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
Closes #90 

I chose not to include a "reset" button because it would encourage unwanted behaviour. There is no same-motion rematch in debating - and when using the team names and debate motion features, you need to change **something** between debates. If you reuse the same configuration between two debates, then something is wrong. Forcing users to go through debate configuration increases likelihood of correct usage.